### PR TITLE
Add WebSocket support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ deps:
 	go get github.com/ian-kent/goose
 	go get github.com/ian-kent/linkio
 	go get github.com/jteeuwen/go-bindata/...
+	go get github.com/gorilla/websocket
 	go get labix.org/v2/mgo
 
 test-deps:

--- a/api/api.go
+++ b/api/api.go
@@ -1,0 +1,23 @@
+package api
+
+import (
+	gohttp "net/http"
+
+	"github.com/gorilla/pat"
+	"github.com/mailhog/MailHog-Server/config"
+)
+
+func CreateAPI(conf *config.Config, r gohttp.Handler) {
+	apiv1 := createAPIv1(conf, r.(*pat.Router))
+	apiv2 := createAPIv2(conf, r.(*pat.Router))
+
+	go func() {
+		for {
+			select {
+			case msg := <-conf.MessageChan:
+				apiv1.messageChan <- msg
+				apiv2.messageChan <- msg
+			}
+		}
+	}()
+}

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 
 	gohttp "net/http"
 
-	"github.com/gorilla/pat"
 	"github.com/ian-kent/go-log/log"
 	"github.com/mailhog/MailHog-Server/api"
 	"github.com/mailhog/MailHog-Server/config"
@@ -37,8 +36,7 @@ func main() {
 
 	exitCh = make(chan int)
 	cb := func(r gohttp.Handler) {
-		api.CreateAPIv1(conf, r.(*pat.Router))
-		api.CreateAPIv2(conf, r.(*pat.Router))
+		api.CreateAPI(conf, r)
 	}
 	go http.Listen(conf.APIBindAddr, assets.Asset, exitCh, cb)
 	go smtp.Listen(conf, exitCh)

--- a/websockets/connection.go
+++ b/websockets/connection.go
@@ -1,0 +1,73 @@
+package websockets
+
+import (
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+const (
+	// Time allowed to write a message to the peer.
+	writeWait = 10 * time.Second
+	// Time allowed to read the next pong message from the peer.
+	pongWait = 60 * time.Second
+	// Send pings to peer with this period. Must be less than pongWait.
+	pingPeriod = (pongWait * 9) / 10
+	// Maximum message size allowed from peer.
+	maxMessageSize = 256
+)
+
+type connection struct {
+	hub  *Hub
+	ws   *websocket.Conn
+	send chan interface{}
+}
+
+func (c *connection) readLoop() {
+	defer func() {
+		c.hub.unregisterChan <- c
+		c.ws.Close()
+	}()
+	c.ws.SetReadLimit(256)
+	c.ws.SetReadDeadline(time.Now().Add(pongWait))
+	c.ws.SetPongHandler(func(string) error { c.ws.SetReadDeadline(time.Now().Add(pongWait)); return nil })
+	for {
+		if _, _, err := c.ws.NextReader(); err != nil {
+			return
+		}
+	}
+}
+
+func (c *connection) writeLoop() {
+	ticker := time.NewTicker(pingPeriod)
+	defer func() {
+		ticker.Stop()
+		c.ws.Close()
+	}()
+	for {
+		select {
+		case message, ok := <-c.send:
+			if !ok {
+				c.writeControl(websocket.CloseMessage)
+				return
+			}
+			if err := c.writeJSON(message); err != nil {
+				return
+			}
+		case <-ticker.C:
+			if err := c.writeControl(websocket.PingMessage); err != nil {
+				return
+			}
+		}
+	}
+}
+
+func (c *connection) writeJSON(message interface{}) error {
+	c.ws.SetWriteDeadline(time.Now().Add(writeWait))
+	return c.ws.WriteJSON(message)
+}
+
+func (c *connection) writeControl(messageType int) error {
+	c.ws.SetWriteDeadline(time.Now().Add(writeWait))
+	return c.ws.WriteMessage(messageType, []byte{})
+}

--- a/websockets/connection.go
+++ b/websockets/connection.go
@@ -13,8 +13,8 @@ const (
 	pongWait = 60 * time.Second
 	// Send pings to peer with this period. Must be less than pongWait.
 	pingPeriod = (pongWait * 9) / 10
-	// Maximum message size allowed from peer.
-	maxMessageSize = 256
+	// Maximum message size allowed from peer. Set to minimum allowed value as we don't expect the client to send non-control messages.
+	maxMessageSize = 1
 )
 
 type connection struct {
@@ -28,7 +28,7 @@ func (c *connection) readLoop() {
 		c.hub.unregisterChan <- c
 		c.ws.Close()
 	}()
-	c.ws.SetReadLimit(256)
+	c.ws.SetReadLimit(maxMessageSize)
 	c.ws.SetReadDeadline(time.Now().Add(pongWait))
 	c.ws.SetPongHandler(func(string) error { c.ws.SetReadDeadline(time.Now().Add(pongWait)); return nil })
 	for {

--- a/websockets/hub.go
+++ b/websockets/hub.go
@@ -1,0 +1,73 @@
+package websockets
+
+import (
+	"net/http"
+
+	"github.com/gorilla/websocket"
+	"github.com/ian-kent/go-log/log"
+)
+
+type Hub struct {
+	upgrader       websocket.Upgrader
+	connections    map[*connection]bool
+	messages       chan interface{}
+	registerChan   chan *connection
+	unregisterChan chan *connection
+}
+
+func NewHub() *Hub {
+	hub := &Hub{
+		upgrader: websocket.Upgrader{
+			ReadBufferSize:  256,
+			WriteBufferSize: 4096,
+		},
+		connections:    make(map[*connection]bool),
+		messages:       make(chan interface{}),
+		registerChan:   make(chan *connection),
+		unregisterChan: make(chan *connection),
+	}
+	go hub.run()
+	return hub
+}
+
+func (h *Hub) run() {
+	for {
+		select {
+		case c := <-h.registerChan:
+			h.connections[c] = true
+		case c := <-h.unregisterChan:
+			h.unregister(c)
+		case m := <-h.messages:
+			for c := range h.connections {
+				select {
+				case c.send <- m:
+				default:
+					h.unregister(c)
+				}
+			}
+		}
+	}
+}
+
+func (h *Hub) unregister(c *connection) {
+	if _, ok := h.connections[c]; ok {
+		close(c.send)
+		delete(h.connections, c)
+	}
+}
+
+func (h *Hub) Serve(w http.ResponseWriter, r *http.Request) {
+	ws, err := h.upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	c := &connection{hub: h, ws: ws, send: make(chan interface{}, 256)}
+	h.registerChan <- c
+	go c.writeLoop()
+	go c.readLoop()
+}
+
+func (h *Hub) Broadcast(data interface{}) {
+	h.messages <- data
+}

--- a/websockets/hub.go
+++ b/websockets/hub.go
@@ -20,6 +20,9 @@ func NewHub() *Hub {
 		upgrader: websocket.Upgrader{
 			ReadBufferSize:  256,
 			WriteBufferSize: 4096,
+			CheckOrigin: func(r *http.Request) bool {
+				return true
+			},
 		},
 		connections:    make(map[*connection]bool),
 		messages:       make(chan interface{}),


### PR DESCRIPTION
This is the server change for my fix for mailhog/MailHog#58

This PR adds a new endpoint to APIv2, which can be used to listen for new messages. The APIv1 event stream is preserved, so new emails are broadcast through both the event stream and websockets.