### PR TITLE
Support downloading and listing messages when using maildir

### DIFF
--- a/api/v1.go
+++ b/api/v1.go
@@ -191,6 +191,14 @@ func (apiv1 *APIv1) download(w http.ResponseWriter, req *http.Request) {
 			}
 		}
 		w.Write([]byte("\r\n" + message.Content.Body))
+	case *storage.Maildir:
+		message, _ := apiv1.config.Storage.(*storage.Maildir).Load(id)
+		for h, l := range message.Content.Headers {
+			for _, v := range l {
+				w.Write([]byte(h + ": " + v + "\r\n"))
+			}
+		}
+		w.Write([]byte("\r\n" + message.Content.Body))
 	default:
 		w.WriteHeader(500)
 	}

--- a/api/v1.go
+++ b/api/v1.go
@@ -136,6 +136,11 @@ func (apiv1 *APIv1) messages(w http.ResponseWriter, req *http.Request) {
 		bytes, _ := json.Marshal(messages)
 		w.Header().Add("Content-Type", "text/json")
 		w.Write(bytes)
+	case *storage.Maildir:
+		messages, _ := apiv1.config.Storage.(*storage.Maildir).List(0, 1000)
+		bytes, _ := json.Marshal(messages)
+		w.Header().Add("Content-Type", "text/json")
+		w.Write(bytes)
 	default:
 		w.WriteHeader(500)
 	}


### PR DESCRIPTION
When using MailHog maildir storage (`-storage maildir`) and requesting the following paths, the server responds with a `500 - Internal Server Error`:
* /api/v1/messages/<id>/download
* /api/v1/messages

None of the cases in the v1 api switches for `messages` or `download` functions are matched when using maildir storage and the default is then used (`default: w.WriteHeader(500)`) causing the server to respond with a HTTP 500 header.

Adding `storage.Maildir` case to these functions resolves this, making it possible to list and download messages when using maildir storage.