### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: go
+sudo: false
+before_script:
+  - go get ./...
 go:
  - 1.6
+ - 1.7.x
+ - 1.8.x
  - tip


### PR DESCRIPTION
Fixed travis build script, now the build is passing https://travis-ci.org/marten-cz/MailHog-Server/builds/266421341 .
As well I added newer versions of golang.