### PR TITLE
Remove APIv1 KEEPALIVE log

### DIFF
--- a/api/v1.go
+++ b/api/v1.go
@@ -103,7 +103,6 @@ func (apiv1 *APIv1) broadcast(json string) {
 // connections. Without this it is possible for the server to become
 // unresponsive due to too many open files.
 func (apiv1 *APIv1) keepalive() {
-	log.Println("[APIv1] KEEPALIVE /api/v1/events")
 	stream.Notify("keepalive", []byte{})
 }
 


### PR DESCRIPTION
I don't really see the point of this log message and my logs always end up polluted with mostly this message, so it would be nice to just remove this instead of piping everything to /dev/null like I do now.