### PR TITLE
Add email blacklist functionality to server components

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,7 @@ func DefaultConfig() *Config {
 		WebPath:      "",
 		MessageChan:  make(chan *data.Message),
 		OutgoingSMTP: make(map[string]*OutgoingSMTP),
+		Blacklist:    make(map[string]bool),
 	}
 }
 
@@ -49,6 +50,7 @@ type Config struct {
 	OutgoingSMTPFile string
 	OutgoingSMTP     map[string]*OutgoingSMTP
 	WebPath          string
+	Blacklist        map[string]bool
 }
 
 // OutgoingSMTP is an outgoing SMTP server config

--- a/smtp/smtp.go
+++ b/smtp/smtp.go
@@ -34,10 +34,7 @@ func Listen(cfg *config.Config, exitCh chan int) *net.TCPListener {
 		go Accept(
 			conn.(*net.TCPConn).RemoteAddr().String(),
 			io.ReadWriteCloser(conn),
-			cfg.Storage,
-			cfg.MessageChan,
-			cfg.Hostname,
-			cfg.Monkey,
+			cfg,
 		)
 	}
 }


### PR DESCRIPTION
## Summary
This PR adds server-side blacklist functionality to MailHog-Server, complementing the main MailHog application blacklist feature.

### Changes Made
- **Config Enhancement**: Added `Blacklist` field to `Config` struct for storing blacklisted email addresses
- **API v2 Endpoints**: Added blacklist management endpoints:
  - `GET /api/v2/blacklist` - List all blacklisted emails
  - `POST /api/v2/blacklist/{email}` - Add email to blacklist
  - `DELETE /api/v2/blacklist/{email}` - Remove email from blacklist
- **SMTP Session Validation**: Enhanced SMTP session handling to validate sender/recipient against blacklist
- **Accept Function**: Updated `Accept()` function signature to receive blacklist parameter

### Technical Details
- **Thread-safe Operations**: Uses map[string]bool for O(1) blacklist lookups
- **SMTP Integration**: Validates both sender (`validateSender`) and recipient (`validateRecipient`) addresses
- **Backward Compatibility**: Changes maintain API compatibility while adding new functionality

### Integration
This PR works in conjunction with the main MailHog repository changes to provide complete blacklist functionality. The server-side components handle the core SMTP validation logic while the main application manages the user interface and configuration.

### Files Modified
- `config/config.go` - Added Blacklist field to Config struct
- `api/v2.go` - Added blacklist API endpoints
- `smtp/session.go` - Added blacklist validation to SMTP session
- `smtp/smtp.go` - Updated Accept function call to pass blacklist

🤖 Generated with [Claude Code](https://claude.ai/code)